### PR TITLE
Minor syntax fixes

### DIFF
--- a/_posts/2015-09-23-CharityCoding.md
+++ b/_posts/2015-09-23-CharityCoding.md
@@ -3,8 +3,8 @@ layout: post
 title:  "Charity Coding"
 date:   2015-09-23
 venue: "Bitcrowd"
-ticket: "Ticket: Available"
-time: "Time: 10am"
+ticket: "Available"
+time: "10am"
 href: "http://www.meetup.com/Berlin-Charity-Coding/events/224899002/"
 ---
 <!-- fill in the URL of your event host page if you haven't enough

--- a/_posts/2015-09-26-djangogirls.md
+++ b/_posts/2015-09-26-djangogirls.md
@@ -3,8 +3,8 @@ layout: post
 title:  "Django Girls"
 date:   2015-09-26
 venue: "Wimdu"
-ticket: "Ticket: Register now"
-time: "Time: 9am"
+ticket: "Register now"
+time: "9am"
 href: "https://djangogirls.org/berlin/"
 ---
 <!-- fill in the URL of your event host page if you haven't enough information for a detail page, so the event link won't point on the detail page at all -->


### PR DESCRIPTION
DjangoGirls and CharityCoding had a ugly double mention in their metadata. I assume from migrating to the new layout. Anyhow, this PR fixes that.

Before:
![screen shot 2015-08-31 at 16 34 33](https://cloud.githubusercontent.com/assets/40496/9581195/3776086a-4ffe-11e5-9307-d1cbca65e088.png)

After:
![screen shot 2015-08-31 at 16 34 22](https://cloud.githubusercontent.com/assets/40496/9581199/3d43540a-4ffe-11e5-9efe-29c3ccefc92f.png)
