### PR TITLE
Add support for ticket sales permalinks

### DIFF
--- a/_includes/event-cta.html
+++ b/_includes/event-cta.html
@@ -9,6 +9,9 @@
     <a href="{{ post.href }}" class="event__status event__status--buy-ticket">RSVP</a>
   {% endif %}
   {% if post.ticket == 'buy' %}
-    <a href="{{ post.href }}" class="event__status event__status--buy-ticket">Buy Ticket</a>
+    <a href="{% if post.ticket_href %}{{ post.ticket_href }}{% else %}{{ post.href }}{% endif %}"
+       class="event__status event__status--buy-ticket">
+       Buy Ticket
+    </a>
   {% endif %}
 </div>

--- a/_posts/2017-02-07-jsconfeu-day-two.md
+++ b/_posts/2017-02-07-jsconfeu-day-two.md
@@ -4,6 +4,7 @@ title:  "JSConf EU Day 2"
 date:   2017-05-07
 venue: "Arena"
 ticket: "buy"
+ticket_href: "https://ti.to/jsconfeu/jsconfeu2017"
 time: "all day"
 href: "http://2017.jsconf.eu/"
 ---

--- a/_posts/2017-05-05-cssconfeu.md
+++ b/_posts/2017-05-05-cssconfeu.md
@@ -4,6 +4,7 @@ title:  "CSSconf EU"
 date:   2017-05-05
 venue: "Arena"
 ticket: "buy"
+ticket_href: "https://ti.to/cssconfeu/cssconfeu-2017"
 time: "all day"
 href: "http://2017.cssconf.eu/"
 ---

--- a/_posts/2017-05-06-jsconfeu-day-one.md
+++ b/_posts/2017-05-06-jsconfeu-day-one.md
@@ -4,6 +4,7 @@ title:  "JSConf EU Day 1"
 date:   2017-05-06
 venue: "Arena"
 ticket: "buy"
+ticket_href: "https://ti.to/jsconfeu/jsconfeu2017"
 time: "all day"
 href: "http://2017.jsconf.eu/"
 ---

--- a/_posts/2017-05-21-GraphQL-Europe.md
+++ b/_posts/2017-05-21-GraphQL-Europe.md
@@ -3,7 +3,8 @@ layout: post
 title: "GraphQL-Europe Conference"
 date: 2017-05-21
 venue: "nhow Berlin"
-ticket: "https://graphql-europe-2017.eventbrite.com/#tickets"
+ticket: "buy"
+ticket_href: "https://graphql-europe-2017.eventbrite.com/#tickets"
 time: "all day"
 href: "https://graphql-europe.org"
 ---


### PR DESCRIPTION
Since I modified the formatter for the events, I’ve spotted a problem with one of items on our list (GraphQL Europe)—the CTA was not visible to the users. Since they wanted to link to the ticket sales directly, I’ve added support for it, and added ticket sales links to all of the events where buying a ticket is mandatory.