### PR TITLE
add graphql europe

### DIFF
--- a/_posts/2018-06-15-graphql-europe.md
+++ b/_posts/2018-06-15-graphql-europe.md
@@ -1,0 +1,10 @@
+---
+layout: post
+title: "GraphQL Europe"
+date: 2018-06-15 08:00:00 UTC+2
+venue: "nHow Hotel"
+ticket: "buy"
+ticket_href: "https://www.eventbrite.com/e/graphql-europe-2018-tickets-39184180940/"
+time: "8am"
+href: "https://www.graphql-europe.org"
+---


### PR DESCRIPTION
Adds the [GraphQL Europe](https://www.graphql-europe.org) conference to the list