### PR TITLE
New event: A11y Meetup Berlin

### DIFF
--- a/_posts/2019-05-28-a11y-meetup-berlin.md
+++ b/_posts/2019-05-28-a11y-meetup-berlin.md
@@ -1,0 +1,9 @@
+---
+layout: post
+title: A11y Meetup Berlin
+date: 2019-05-28 18:00:00 UTC+2
+venue: WeWork, Stresemannstraße 123
+ticket: free
+time: 6pm - 8pm
+href: https://a11y-meetup-berlin.de/
+---


### PR DESCRIPTION
## Description
The following PR adds the info for the upcoming 7th edition of the [A11y Meetup Berlin](https://a11y-meetup-berlin.de/) which will take place on May 28th, 2019.