### PR TITLE
add(post): js beginner workshop on may 24 + 25

### DIFF
--- a/_posts/2019-05-24-js-workshop-install-party.md
+++ b/_posts/2019-05-24-js-workshop-install-party.md
@@ -1,0 +1,10 @@
+---
+layout: post
+title: JavaScript for Beginners - Installation Party
+date: 2019-05-24 19:30:00 UTC+2
+venue: co.up, Adalbertstraße 8, 10999 Berlin, Germany
+ticket: rsvp
+ticket_href: https://docs.google.com/forms/d/1wYEYgMuSsPntaC_tHY6Yz9VUqtjGRCniWZQ5jzNVI6U/
+time: 7:30PM - 9PM
+href: https://www.meetup.com/Ember-js-Berlin/events/260668921/
+---

--- a/_posts/2019-05-25-js-workshop-day.md
+++ b/_posts/2019-05-25-js-workshop-day.md
@@ -1,0 +1,10 @@
+---
+layout: post
+title: JavaScript for Beginners - Build Your First Web App with EmberJS
+date: 2019-05-25 09:00:00 UTC+2
+venue: co.up, Adalbertstraße 8, 10999 Berlin, Germany
+ticket: rsvp
+ticket_href: https://docs.google.com/forms/d/1wYEYgMuSsPntaC_tHY6Yz9VUqtjGRCniWZQ5jzNVI6U/
+time: 9AM - 6PM
+href: https://www.meetup.com/Ember-js-Berlin/events/260668987/
+---


### PR DESCRIPTION
My company and me are organising a one and a half day JavaScript beginner workshop in the week leading up to JSConf EU which is open to women and those who are non-binary. This adds the related events to the website:

<img width="1143" alt="Screenshot 2019-04-30 at 11 50 09" src="https://user-images.githubusercontent.com/8811742/56954328-cd6b0c80-6b3e-11e9-8829-4eed56121e41.png">
