### PR TITLE
Update link to sign up page

### DIFF
--- a/_posts/2019-06-03-codebar-berlin.md
+++ b/_posts/2019-06-03-codebar-berlin.md
@@ -5,5 +5,5 @@ date: 2019-06-03 18:30:00 UTC+2
 venue: Blinkist, Sonnenallee 223, 12059 Berlin, Germany
 ticket: rsvp
 time: 6:30PM - 9PM
-href: https://codebar.io/events
+href: https://codebar.io/workshops/1227
 ---


### PR DESCRIPTION
At the time of the initial commit we didn't have a page listed, so we linked to our generic page for future events