### PR TITLE
Add AMP Roadshow event

### DIFF
--- a/_posts/2019-06-07-amp-roadshow.md
+++ b/_posts/2019-06-07-amp-roadshow.md
@@ -1,0 +1,10 @@
+---
+layout: post
+title: AMP Roadshow Berlin 
+date: 2019-06-07 09:00:00 UTC+2
+venue: Google Berlin
+ticket: rsvp
+ticket_href: https://events.withgoogle.com/amp-roadshow-berlin/
+time: 9am - 5pm
+href: https://amp.dev/events/amp-roadshow
+---


### PR DESCRIPTION
Note that I couldn't get the `ticket_href` field to work for `ticket: rsvp`. I don't see it working on other events too, as in, the "RSVP" and "Website" links are always the same.